### PR TITLE
feat(playground): add Timeline component and showcase playground

### DIFF
--- a/app/playground/page.jsx
+++ b/app/playground/page.jsx
@@ -98,11 +98,7 @@ export default function Playground() {
         <p className="mt-2 text-neutral-400 text-xs">A sandbox for previewing UI components.</p>
       </div>
 
-      <ComponentShowcase
-        code="'@vault'"
-        description="Renders a timeline of events."
-        title="Timeline"
-      >
+      <ComponentShowcase description="Renders a timeline of events." title="Timeline">
         <Timeline items={timelineItems} />
       </ComponentShowcase>
     </div>

--- a/app/playground/page.jsx
+++ b/app/playground/page.jsx
@@ -92,7 +92,7 @@ const timelineItems = [
 
 export default function Playground() {
   return (
-    <div className="flex w-full flex-col items-start gap-12 pb-20">
+    <div className="flex w-full flex-col items-start gap-12 pb-28">
       <div>
         <h1 className="font-medium text-sm sm:text-base">Playground</h1>
         <p className="mt-2 text-neutral-400 text-xs">A sandbox for previewing UI components.</p>

--- a/app/playground/page.jsx
+++ b/app/playground/page.jsx
@@ -1,0 +1,110 @@
+import { ComponentShowcase } from "@components/playground/ComponentShowcase";
+import { Timeline } from "@components/ui/timeline";
+
+export const metadata = {
+  description: "A sandbox for previewing UI components.",
+  title: "Playground",
+};
+
+const timelineItems = [
+  {
+    description: "The user session timed out due to inactivity.",
+    id: "auth-timeout",
+    status: "error",
+    time: "Just now",
+    title: "Authenticated timed out",
+  },
+  {
+    children: [
+      {
+        description: "The user session timed out due to inactivity.",
+        id: "cres-1",
+        status: "success",
+        time: "1m ago",
+        title: "CRes received",
+      },
+      {
+        children: [
+          {
+            description: "The user session timed out due to inactivity.",
+            id: "cres-2",
+            status: "success",
+            time: "1m ago",
+            title: "CRes received",
+          },
+          {
+            description: "The user session timed out due to inactivity.",
+            id: "creq-1",
+            status: "warning",
+            time: "2m ago",
+            title: "CReq sent",
+          },
+        ],
+        defaultOpen: true,
+        id: "challenge-2",
+        title: "Challenge performed",
+      },
+      {
+        description: "The user session timed out due to inactivity.",
+        id: "creq-2",
+        status: "warning",
+        time: "2m ago",
+        title: "CReq sent",
+      },
+    ],
+    id: "challenge-3",
+    title: "Challenge performed",
+  },
+  {
+    description: "Issuer requires a challenge to be performed.",
+    id: "action-required",
+    status: "pending",
+    time: "3m ago",
+    title: "Action required",
+  },
+  {
+    children: [
+      {
+        description: "The user resumed an existing session.",
+        id: "session-resumed",
+        status: "success",
+        time: "5m ago",
+        title: "Session resumed",
+      },
+      {
+        description: "The authentication flow was initiated.",
+        id: "auth-started",
+        status: "info",
+        time: "5m ago",
+        title: "Authentication started",
+      },
+    ],
+    id: "more",
+  },
+  {
+    description: "A new session was created for the user.",
+    id: "session-created",
+    status: "info",
+    time: "6m ago",
+    title: "Session created",
+  },
+];
+
+export default function Playground() {
+  return (
+    <div className="flex w-full flex-col items-start gap-12">
+      <div>
+        <h1 className="font-medium text-sm sm:text-base">Playground</h1>
+        <p className="mt-2 text-neutral-400 text-xs">A sandbox for previewing UI components.</p>
+      </div>
+
+      <ComponentShowcase
+        code="'@vault'"
+        description="Renders a timeline of events."
+        title="Timeline"
+      >
+        <Timeline items={timelineItems} />
+      </ComponentShowcase>
+    </div>
+  );
+}

--- a/app/playground/page.jsx
+++ b/app/playground/page.jsx
@@ -92,7 +92,7 @@ const timelineItems = [
 
 export default function Playground() {
   return (
-    <div className="flex w-full flex-col items-start gap-12">
+    <div className="flex w-full flex-col items-start gap-12 pb-20">
       <div>
         <h1 className="font-medium text-sm sm:text-base">Playground</h1>
         <p className="mt-2 text-neutral-400 text-xs">A sandbox for previewing UI components.</p>

--- a/components/playground/ComponentShowcase.jsx
+++ b/components/playground/ComponentShowcase.jsx
@@ -20,7 +20,7 @@ function CopyButton({ value }) {
   return (
     <button
       aria-label="Copy import"
-      className="shrink-0 text-neutral-400 transition-colors hover:text-p3-text"
+      className="shrink-0 text-neutral-400 transition-colors hover:text-p3-text dark:hover:text-p3-text-dark"
       onClick={copy}
       type="button"
     >
@@ -36,16 +36,16 @@ function CopyButton({ value }) {
 export function ComponentShowcase({ title, description, code, children, className }) {
   return (
     <section className={cn("w-full", className)}>
-      <h2 className="font-semibold text-lg text-p3-text">{title}</h2>
+      <h2 className="font-semibold text-lg text-p3-text dark:text-p3-text-dark">{title}</h2>
       {description && <p className="mt-1 text-neutral-400 text-sm">{description}</p>}
 
       {code && (
-        <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-p3-border bg-p3-background px-3 py-2.5">
+        <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-p3-border bg-p3-background-light px-3 py-2.5 dark:border-p3-border-dark dark:bg-p3-background-dark">
           <code className="overflow-x-auto whitespace-nowrap font-mono text-xs">
             <span className="text-purple-500 dark:text-purple-400">import </span>
-            <span className="text-p3-text">{"{ "}</span>
+            <span className="text-p3-text dark:text-p3-text-dark">{"{ "}</span>
             <span className="text-sky-600 dark:text-sky-400">{title}</span>
-            <span className="text-p3-text">{" } "}</span>
+            <span className="text-p3-text dark:text-p3-text-dark">{" } "}</span>
             <span className="text-purple-500 dark:text-purple-400">from </span>
             <span className="text-amber-600 dark:text-amber-400">{code}</span>
           </code>
@@ -53,7 +53,9 @@ export function ComponentShowcase({ title, description, code, children, classNam
         </div>
       )}
 
-      <div className="mt-4 rounded-xl border border-p3-border bg-p3-background p-5">{children}</div>
+      <div className="mt-4 rounded-xl border border-p3-border bg-p3-background-light p-5 dark:border-p3-border-dark dark:bg-p3-background-dark">
+        {children}
+      </div>
     </section>
   );
 }

--- a/components/playground/ComponentShowcase.jsx
+++ b/components/playground/ComponentShowcase.jsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { cn } from "@lib/utils";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+function CopyButton({ value }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  return (
+    <button
+      aria-label="Copy import"
+      className="shrink-0 text-neutral-400 transition-colors hover:text-p3-text"
+      onClick={copy}
+      type="button"
+    >
+      {copied ? <Check className="size-4 text-green-500" /> : <Copy className="size-4" />}
+    </button>
+  );
+}
+
+/**
+ * Doc-style showcase card: title, description, copyable import snippet and a
+ * live preview area. Mirrors the registry/playground layout.
+ */
+export function ComponentShowcase({ title, description, code, children, className }) {
+  return (
+    <section className={cn("w-full", className)}>
+      <h2 className="font-semibold text-lg text-p3-text">{title}</h2>
+      {description && <p className="mt-1 text-neutral-400 text-sm">{description}</p>}
+
+      {code && (
+        <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-p3-border bg-p3-background px-3 py-2.5">
+          <code className="overflow-x-auto whitespace-nowrap font-mono text-xs">
+            <span className="text-purple-500 dark:text-purple-400">import </span>
+            <span className="text-p3-text">{"{ "}</span>
+            <span className="text-sky-600 dark:text-sky-400">{title}</span>
+            <span className="text-p3-text">{" } "}</span>
+            <span className="text-purple-500 dark:text-purple-400">from </span>
+            <span className="text-amber-600 dark:text-amber-400">{code}</span>
+          </code>
+          <CopyButton value={`import { ${title} } from ${code}`} />
+        </div>
+      )}
+
+      <div className="mt-4 rounded-xl border border-p3-border bg-p3-background p-5">{children}</div>
+    </section>
+  );
+}

--- a/components/ui/timeline.jsx
+++ b/components/ui/timeline.jsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { cn } from "@lib/utils";
+import { ChevronRight, CircleCheck, CircleDot, CircleX, Clock, Plus } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Status → icon + color mapping for leaf timeline events.
+ * Colors lean on raw palette tokens (with dark variants) since these are
+ * semantic states, not theme surface colors.
+ */
+const STATUS = {
+  error: { className: "text-red-500 dark:text-red-400", icon: CircleX },
+  info: { className: "text-neutral-400 dark:text-neutral-500", icon: CircleDot },
+  pending: { className: "text-amber-500 dark:text-amber-400", icon: Clock },
+  success: { className: "text-green-600 dark:text-green-400", icon: CircleCheck },
+  warning: { className: "text-amber-500 dark:text-amber-400", icon: CircleDot },
+};
+
+function EventMarker({ status }) {
+  const { icon: Icon, className } = STATUS[status] ?? STATUS.info;
+  return (
+    <span className="absolute top-0.5 left-0 flex size-[18px] items-center justify-center bg-p3-background">
+      <Icon className={cn("size-[18px]", className)} strokeWidth={2} />
+    </span>
+  );
+}
+
+function GroupToggle({ open, onClick }) {
+  return (
+    <button
+      aria-expanded={open}
+      className="absolute top-0.5 left-0 flex size-[18px] items-center justify-center rounded-full border border-p3-border bg-p3-background text-neutral-500 transition-colors hover:text-p3-text"
+      onClick={onClick}
+      type="button"
+    >
+      <Plus className={cn("size-3 transition-transform", open && "rotate-45")} strokeWidth={2.5} />
+    </button>
+  );
+}
+
+function TimelineItem({ item, isLast }) {
+  const isGroup = Array.isArray(item.children) && item.children.length > 0;
+  const [open, setOpen] = useState(item.defaultOpen ?? false);
+
+  return (
+    <li className="relative pl-7">
+      {/* connector line */}
+      {!isLast && (
+        <span aria-hidden className="absolute top-5 bottom-0 left-[8px] w-px bg-p3-border" />
+      )}
+
+      {isGroup ? (
+        <GroupToggle onClick={() => setOpen((v) => !v)} open={open} />
+      ) : (
+        <EventMarker status={item.status} />
+      )}
+
+      {isGroup ? (
+        <div>
+          <button
+            className="group flex items-center gap-1.5 text-left"
+            onClick={() => setOpen((v) => !v)}
+            type="button"
+          >
+            {item.title && <span className="font-medium text-p3-text text-sm">{item.title}</span>}
+            <span className="text-neutral-400 text-xs">
+              {item.title
+                ? `${item.children.length} events`
+                : `${item.children.length} more events`}
+            </span>
+            <ChevronRight
+              className={cn("size-3.5 text-neutral-400 transition-transform", open && "rotate-90")}
+            />
+          </button>
+
+          {open && (
+            <ul className="mt-2 space-y-4">
+              {item.children.map((child, i) => (
+                <TimelineItem
+                  isLast={i === item.children.length - 1}
+                  item={child}
+                  key={child.id ?? i}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-0.5">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-p3-text text-sm">{item.title}</span>
+            {item.time && <span className="text-neutral-400 text-xs">{item.time}</span>}
+          </div>
+          {item.description && (
+            <p className="text-neutral-500 text-xs dark:text-neutral-400">{item.description}</p>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Timeline — renders a (optionally nested) timeline of events.
+ *
+ * @param {Object[]} items - event nodes
+ * @param {string}   items[].title       - event label (omit on a group to render "N more events")
+ * @param {string}  [items[].time]       - pre-formatted relative time, e.g. "1m ago"
+ * @param {string}  [items[].description]
+ * @param {('error'|'success'|'warning'|'pending'|'info')} [items[].status] - leaf marker
+ * @param {Object[]} [items[].children]  - nested events; turns the node into a collapsible group
+ * @param {boolean} [items[].defaultOpen]
+ */
+export function Timeline({ items = [], className }) {
+  return (
+    <ul className={cn("space-y-4", className)}>
+      {items.map((item, i) => (
+        <TimelineItem isLast={i === items.length - 1} item={item} key={item.id ?? i} />
+      ))}
+    </ul>
+  );
+}

--- a/components/ui/timeline.jsx
+++ b/components/ui/timeline.jsx
@@ -3,7 +3,7 @@
 import { cn } from "@lib/utils";
 import { ChevronRight, CircleCheck, CircleDot, CircleX, Clock, Plus } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Status → icon + color mapping for leaf timeline events.
@@ -19,12 +19,8 @@ const STATUS = {
 };
 
 const INDENT = 22; // px each nesting level shifts right
-const MARKER = 18; // px marker size
 const RADIUS = 8; // px connector corner radius
 const GAP = 10; // px vertical approach into a marker after a turn
-const center = (level) => level * INDENT + MARKER / 2;
-
-const lineCls = "absolute z-0 border-p3-border dark:border-p3-border-dark";
 
 function EventMarker({ status }) {
   const { icon: Icon, className } = STATUS[status] ?? STATUS.info;
@@ -45,89 +41,12 @@ function GroupToggle({ open, onClick }) {
   );
 }
 
-/**
- * Vertical line + rounded turn leaving this marker toward the next visible row.
- * Straight when the level is unchanged; an elbow (stopping a corner-radius short
- * of the next marker, so the next row's incoming corner completes the curve)
- * when stepping into or out of a nesting level.
- */
-function OutgoingLine({ level, nextLevel, top }) {
-  if (nextLevel == null) return null;
-  const c = center(level);
-
-  if (nextLevel === level) {
-    return (
-      <span aria-hidden className={cn(lineCls, "border-l")} style={{ bottom: 0, left: c, top }} />
-    );
-  }
-
-  const n = center(nextLevel);
-  if (nextLevel > level) {
-    // step right: vertical (border-l) at c, floor turning right toward n
-    return (
-      <span
-        aria-hidden
-        className={cn(lineCls, "rounded-bl-[8px] border-b border-l")}
-        style={{ bottom: 0, left: c, top, width: n - RADIUS - c }}
-      />
-    );
-  }
-  // step left: vertical (border-r) at c, floor turning left toward n.
-  // Right edge is c + 1 so the 1px border lands on the same column as border-l.
-  return (
-    <span
-      aria-hidden
-      className={cn(lineCls, "rounded-br-[8px] border-r border-b")}
-      style={{ bottom: 0, left: n + RADIUS, top, width: c + 1 - RADIUS - n }}
-    />
-  );
-}
-
-/**
- * Rounded turn arriving at this marker from the previous row, plus a short
- * vertical drop into the marker — only when the previous row sat at a different
- * level. This is the second half of an elbow and gives the marker breathing
- * room from the curve.
- */
-function IncomingLine({ level, prevLevel }) {
-  if (prevLevel == null || prevLevel === level) return null;
-  const c = center(level);
-
-  if (prevLevel < level) {
-    // arrived from the left (stepping in): top-right rounded corner.
-    // Right edge is c + 1 so the 1px border lands on the same column as border-l.
-    return (
-      <span
-        aria-hidden
-        className={cn(lineCls, "rounded-tr-[8px] border-t border-r")}
-        style={{ height: GAP, left: c - RADIUS, top: 0, width: RADIUS + 1 }}
-      />
-    );
-  }
-  // arrived from the right (stepping out): top-left rounded corner
-  return (
-    <span
-      aria-hidden
-      className={cn(lineCls, "rounded-tl-[8px] border-t border-l")}
-      style={{ height: GAP, left: c, top: 0, width: RADIUS }}
-    />
-  );
-}
-
-function Row({ row, prevLevel, nextLevel }) {
+function Row({ row, markerRef }) {
   const { item, level, isGroup, open, onToggle } = row;
-  const stepped = prevLevel != null && prevLevel !== level;
-  const markerTop = stepped ? GAP : 0;
 
   return (
-    <div
-      className="relative flex items-start gap-2"
-      style={{ paddingLeft: level * INDENT, paddingTop: markerTop }}
-    >
-      <IncomingLine level={level} prevLevel={prevLevel} />
-      <OutgoingLine level={level} nextLevel={nextLevel} top={markerTop + MARKER} />
-
-      <div className="relative z-10 shrink-0">
+    <div className="relative flex items-start gap-2" style={{ paddingLeft: level * INDENT }}>
+      <div className="relative z-10 shrink-0" ref={markerRef}>
         {isGroup ? (
           <GroupToggle onClick={onToggle} open={open} />
         ) : (
@@ -195,8 +114,54 @@ function flatten(items, openIds, level, parentKey, acc) {
 }
 
 /**
+ * Build a single SVG path that links each marker to the next as one continuous
+ * line. Same-column hops are straight verticals; column changes weave through a
+ * rounded elbow that descends at the source column, runs a floor, then drops
+ * into the next marker. Coordinates are snapped to the pixel grid (+0.5) so the
+ * 1px stroke stays crisp on the straight runs.
+ */
+function buildPath(points) {
+  const segs = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    if (!a || !b) continue;
+
+    const x1 = Math.round(a.cx) + 0.5;
+    const x2 = Math.round(b.cx) + 0.5;
+    const y1 = Math.round(a.bottom) + 0.5;
+    const y2 = Math.round(b.top) + 0.5;
+
+    if (x1 === x2) {
+      segs.push(`M${x1} ${y1}L${x2} ${y2}`);
+      continue;
+    }
+
+    const dir = x2 > x1 ? 1 : -1;
+    // Turn as we approach the next marker, leaving GAP of straight drop into it.
+    const turnY = Math.round(y2 - GAP) + 0.5;
+    // Don't let the elbow climb above where the line starts on short rows.
+    const r = Math.min(RADIUS, Math.max(0, turnY - y1), Math.abs(x2 - x1) / 2);
+
+    segs.push(
+      `M${x1} ${y1}` +
+        `L${x1} ${turnY - r}` +
+        `Q${x1} ${turnY} ${x1 + dir * r} ${turnY}` +
+        `L${x2 - dir * r} ${turnY}` +
+        `Q${x2} ${turnY} ${x2} ${turnY + r}` +
+        `L${x2} ${y2}`,
+    );
+  }
+  return segs.join(" ");
+}
+
+/**
  * Timeline — renders a (optionally nested) timeline of events as one continuous
  * line that weaves into and out of collapsible groups.
+ *
+ * The connector is a single SVG path measured from the live marker positions, so
+ * it stays seamless across row boundaries (no per-row border segments to align)
+ * and re-traces itself as groups expand/collapse via a ResizeObserver.
  *
  * @param {Object[]} items - event nodes
  * @param {string}   items[].title       - event label (omit on a group to render "N more events")
@@ -208,6 +173,10 @@ function flatten(items, openIds, level, parentKey, acc) {
  */
 export function Timeline({ items = [], className }) {
   const [openIds, setOpenIds] = useState(() => collectOpen(items, "", new Set()));
+  const [path, setPath] = useState("");
+
+  const containerRef = useRef(null);
+  const markerRefs = useRef(new Map());
 
   const toggle = (key) =>
     setOpenIds((prev) => {
@@ -222,10 +191,46 @@ export function Timeline({ items = [], className }) {
 
   const rows = flatten(items, openIds, 0, "", []);
 
+  const measure = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const base = container.getBoundingClientRect();
+    const points = rows.map((row) => {
+      const el = markerRefs.current.get(row.key);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return {
+        bottom: r.bottom - base.top,
+        cx: r.left - base.left + r.width / 2,
+        top: r.top - base.top,
+      };
+    });
+    setPath(buildPath(points));
+  }, [rows]);
+
+  // Re-trace after every commit (open/close, content changes) and on any size
+  // change — the latter covers the height animation frames and viewport resizes.
+  useLayoutEffect(() => {
+    measure();
+    const container = containerRef.current;
+    if (!container) return;
+    const ro = new ResizeObserver(() => measure());
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [measure]);
+
   return (
-    <div className={cn("flex flex-col", className)}>
+    <div className={cn("relative flex flex-col", className)} ref={containerRef}>
+      <svg
+        aria-hidden
+        className="pointer-events-none absolute inset-0 z-0 h-full w-full overflow-visible text-p3-border dark:text-p3-border-dark"
+        fill="none"
+      >
+        <path d={path} stroke="currentColor" strokeWidth="1" />
+      </svg>
+
       <AnimatePresence initial={false}>
-        {rows.map((row, i) => (
+        {rows.map((row) => (
           <motion.div
             animate={{ height: "auto", opacity: 1 }}
             className="overflow-hidden"
@@ -235,8 +240,10 @@ export function Timeline({ items = [], className }) {
             transition={{ duration: 0.18, ease: "easeOut" }}
           >
             <Row
-              nextLevel={i < rows.length - 1 ? rows[i + 1].level : null}
-              prevLevel={i > 0 ? rows[i - 1].level : null}
+              markerRef={(el) => {
+                if (el) markerRefs.current.set(row.key, el);
+                else markerRefs.current.delete(row.key);
+              }}
               row={{ ...row, onToggle: () => toggle(row.key) }}
             />
           </motion.div>

--- a/components/ui/timeline.jsx
+++ b/components/ui/timeline.jsx
@@ -63,7 +63,7 @@ function OutgoingLine({ level, nextLevel, top }) {
 
   const n = center(nextLevel);
   if (nextLevel > level) {
-    // step right: vertical at c, floor turning right toward n
+    // step right: vertical (border-l) at c, floor turning right toward n
     return (
       <span
         aria-hidden
@@ -72,12 +72,13 @@ function OutgoingLine({ level, nextLevel, top }) {
       />
     );
   }
-  // step left: vertical at c, floor turning left toward n
+  // step left: vertical (border-r) at c, floor turning left toward n.
+  // Right edge is c + 1 so the 1px border lands on the same column as border-l.
   return (
     <span
       aria-hidden
       className={cn(lineCls, "rounded-br-[8px] border-r border-b")}
-      style={{ bottom: 0, left: n + RADIUS, top, width: c - RADIUS - n }}
+      style={{ bottom: 0, left: n + RADIUS, top, width: c + 1 - RADIUS - n }}
     />
   );
 }
@@ -93,12 +94,13 @@ function IncomingLine({ level, prevLevel }) {
   const c = center(level);
 
   if (prevLevel < level) {
-    // arrived from the left (stepping in): top-right rounded corner
+    // arrived from the left (stepping in): top-right rounded corner.
+    // Right edge is c + 1 so the 1px border lands on the same column as border-l.
     return (
       <span
         aria-hidden
         className={cn(lineCls, "rounded-tr-[8px] border-t border-r")}
-        style={{ height: GAP, left: c - RADIUS, top: 0, width: RADIUS }}
+        style={{ height: GAP, left: c - RADIUS, top: 0, width: RADIUS + 1 }}
       />
     );
   }

--- a/components/ui/timeline.jsx
+++ b/components/ui/timeline.jsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@lib/utils";
 import { ChevronRight, CircleCheck, CircleDot, CircleX, Clock, Plus } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 
 /**
@@ -19,7 +20,11 @@ const STATUS = {
 
 const INDENT = 22; // px each nesting level shifts right
 const MARKER = 18; // px marker size
+const RADIUS = 8; // px connector corner radius
+const GAP = 10; // px vertical approach into a marker after a turn
 const center = (level) => level * INDENT + MARKER / 2;
+
+const lineCls = "absolute z-0 border-p3-border dark:border-p3-border-dark";
 
 function EventMarker({ status }) {
   const { icon: Icon, className } = STATUS[status] ?? STATUS.info;
@@ -41,49 +46,84 @@ function GroupToggle({ open, onClick }) {
 }
 
 /**
- * A single connector running from this row's marker to the next visible row's
- * marker. Straight when the level is unchanged; a rounded elbow when entering
- * (step right) or leaving (step left) a nesting level — together these form one
- * continuous line that weaves into and out of nested groups.
+ * Vertical line + rounded turn leaving this marker toward the next visible row.
+ * Straight when the level is unchanged; an elbow (stopping a corner-radius short
+ * of the next marker, so the next row's incoming corner completes the curve)
+ * when stepping into or out of a nesting level.
  */
-function Connector({ level, nextLevel }) {
+function OutgoingLine({ level, nextLevel, top }) {
+  if (nextLevel == null) return null;
   const c = center(level);
-  const n = center(nextLevel);
-  const base = "absolute z-0 border-p3-border dark:border-p3-border-dark";
 
   if (nextLevel === level) {
     return (
-      <span
-        aria-hidden
-        className={cn(base, "border-l")}
-        style={{ bottom: 0, left: c, top: MARKER }}
-      />
+      <span aria-hidden className={cn(lineCls, "border-l")} style={{ bottom: 0, left: c, top }} />
     );
   }
+
+  const n = center(nextLevel);
   if (nextLevel > level) {
+    // step right: vertical at c, floor turning right toward n
     return (
       <span
         aria-hidden
-        className={cn(base, "rounded-bl-[10px] border-b border-l")}
-        style={{ bottom: 0, left: c, top: MARKER, width: n - c }}
+        className={cn(lineCls, "rounded-bl-[8px] border-b border-l")}
+        style={{ bottom: 0, left: c, top, width: n - RADIUS - c }}
       />
     );
   }
+  // step left: vertical at c, floor turning left toward n
   return (
     <span
       aria-hidden
-      className={cn(base, "rounded-br-[10px] border-r border-b")}
-      style={{ bottom: 0, left: n, top: MARKER, width: c - n }}
+      className={cn(lineCls, "rounded-br-[8px] border-r border-b")}
+      style={{ bottom: 0, left: n + RADIUS, top, width: c - RADIUS - n }}
     />
   );
 }
 
-function Row({ row, nextLevel }) {
+/**
+ * Rounded turn arriving at this marker from the previous row, plus a short
+ * vertical drop into the marker — only when the previous row sat at a different
+ * level. This is the second half of an elbow and gives the marker breathing
+ * room from the curve.
+ */
+function IncomingLine({ level, prevLevel }) {
+  if (prevLevel == null || prevLevel === level) return null;
+  const c = center(level);
+
+  if (prevLevel < level) {
+    // arrived from the left (stepping in): top-right rounded corner
+    return (
+      <span
+        aria-hidden
+        className={cn(lineCls, "rounded-tr-[8px] border-t border-r")}
+        style={{ height: GAP, left: c - RADIUS, top: 0, width: RADIUS }}
+      />
+    );
+  }
+  // arrived from the right (stepping out): top-left rounded corner
+  return (
+    <span
+      aria-hidden
+      className={cn(lineCls, "rounded-tl-[8px] border-t border-l")}
+      style={{ height: GAP, left: c, top: 0, width: RADIUS }}
+    />
+  );
+}
+
+function Row({ row, prevLevel, nextLevel }) {
   const { item, level, isGroup, open, onToggle } = row;
+  const stepped = prevLevel != null && prevLevel !== level;
+  const markerTop = stepped ? GAP : 0;
 
   return (
-    <div className="relative flex items-start gap-2" style={{ paddingLeft: level * INDENT }}>
-      {nextLevel != null && <Connector level={level} nextLevel={nextLevel} />}
+    <div
+      className="relative flex items-start gap-2"
+      style={{ paddingLeft: level * INDENT, paddingTop: markerTop }}
+    >
+      <IncomingLine level={level} prevLevel={prevLevel} />
+      <OutgoingLine level={level} nextLevel={nextLevel} top={markerTop + MARKER} />
 
       <div className="relative z-10 shrink-0">
         {isGroup ? (
@@ -170,7 +210,11 @@ export function Timeline({ items = [], className }) {
   const toggle = (key) =>
     setOpenIds((prev) => {
       const next = new Set(prev);
-      next.has(key) ? next.delete(key) : next.add(key);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
       return next;
     });
 
@@ -178,13 +222,24 @@ export function Timeline({ items = [], className }) {
 
   return (
     <div className={cn("flex flex-col", className)}>
-      {rows.map((row, i) => (
-        <Row
-          key={row.key}
-          nextLevel={i < rows.length - 1 ? rows[i + 1].level : null}
-          row={{ ...row, onToggle: () => toggle(row.key) }}
-        />
-      ))}
+      <AnimatePresence initial={false}>
+        {rows.map((row, i) => (
+          <motion.div
+            animate={{ height: "auto", opacity: 1 }}
+            className="overflow-hidden"
+            exit={{ height: 0, opacity: 0 }}
+            initial={{ height: 0, opacity: 0 }}
+            key={row.key}
+            transition={{ duration: 0.18, ease: "easeOut" }}
+          >
+            <Row
+              nextLevel={i < rows.length - 1 ? rows[i + 1].level : null}
+              prevLevel={i > 0 ? rows[i - 1].level : null}
+              row={{ ...row, onToggle: () => toggle(row.key) }}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </div>
   );
 }

--- a/components/ui/timeline.jsx
+++ b/components/ui/timeline.jsx
@@ -19,18 +19,15 @@ const STATUS = {
 
 function EventMarker({ status }) {
   const { icon: Icon, className } = STATUS[status] ?? STATUS.info;
-  return (
-    <span className="absolute top-0.5 left-0 flex size-[18px] items-center justify-center bg-p3-background">
-      <Icon className={cn("size-[18px]", className)} strokeWidth={2} />
-    </span>
-  );
+  return <Icon className={cn("size-[18px] shrink-0", className)} strokeWidth={2} />;
 }
 
 function GroupToggle({ open, onClick }) {
   return (
     <button
       aria-expanded={open}
-      className="absolute top-0.5 left-0 flex size-[18px] items-center justify-center rounded-full border border-p3-border bg-p3-background text-neutral-500 transition-colors hover:text-p3-text"
+      aria-label={open ? "Collapse group" : "Expand group"}
+      className="flex size-[18px] shrink-0 items-center justify-center rounded-full border border-p3-border text-neutral-500 transition-colors hover:text-p3-text dark:border-p3-border-dark dark:hover:text-p3-text-dark"
       onClick={onClick}
       type="button"
     >
@@ -42,61 +39,71 @@ function GroupToggle({ open, onClick }) {
 function TimelineItem({ item, isLast }) {
   const isGroup = Array.isArray(item.children) && item.children.length > 0;
   const [open, setOpen] = useState(item.defaultOpen ?? false);
+  const toggle = () => setOpen((v) => !v);
 
   return (
-    <li className="relative pl-7">
-      {/* connector line */}
-      {!isLast && (
-        <span aria-hidden className="absolute top-5 bottom-0 left-[8px] w-px bg-p3-border" />
-      )}
+    <li className="flex gap-3">
+      {/* gutter: marker on top, connector line growing toward the next item */}
+      <div className="flex flex-col items-center">
+        {isGroup ? (
+          <GroupToggle onClick={toggle} open={open} />
+        ) : (
+          <EventMarker status={item.status} />
+        )}
+        {!isLast && (
+          <span aria-hidden className="mt-1.5 w-px grow bg-p3-border dark:bg-p3-border-dark" />
+        )}
+      </div>
 
-      {isGroup ? (
-        <GroupToggle onClick={() => setOpen((v) => !v)} open={open} />
-      ) : (
-        <EventMarker status={item.status} />
-      )}
+      {/* content */}
+      <div className={cn("min-w-0 flex-1", !isLast && "pb-4")}>
+        {isGroup ? (
+          <>
+            <button className="flex items-center gap-1.5 text-left" onClick={toggle} type="button">
+              {item.title && (
+                <span className="font-medium text-p3-text text-sm dark:text-p3-text-dark">
+                  {item.title}
+                </span>
+              )}
+              <span className="text-neutral-400 text-xs">
+                {item.title
+                  ? `${item.children.length} events`
+                  : `${item.children.length} more events`}
+              </span>
+              <ChevronRight
+                className={cn(
+                  "size-3.5 text-neutral-400 transition-transform",
+                  open && "rotate-90",
+                )}
+              />
+            </button>
 
-      {isGroup ? (
-        <div>
-          <button
-            className="group flex items-center gap-1.5 text-left"
-            onClick={() => setOpen((v) => !v)}
-            type="button"
-          >
-            {item.title && <span className="font-medium text-p3-text text-sm">{item.title}</span>}
-            <span className="text-neutral-400 text-xs">
-              {item.title
-                ? `${item.children.length} events`
-                : `${item.children.length} more events`}
-            </span>
-            <ChevronRight
-              className={cn("size-3.5 text-neutral-400 transition-transform", open && "rotate-90")}
-            />
-          </button>
-
-          {open && (
-            <ul className="mt-2 space-y-4">
-              {item.children.map((child, i) => (
-                <TimelineItem
-                  isLast={i === item.children.length - 1}
-                  item={child}
-                  key={child.id ?? i}
-                />
-              ))}
-            </ul>
-          )}
-        </div>
-      ) : (
-        <div className="space-y-0.5">
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-p3-text text-sm">{item.title}</span>
-            {item.time && <span className="text-neutral-400 text-xs">{item.time}</span>}
+            {open && (
+              <ul className="mt-4 space-y-0">
+                {item.children.map((child, i) => (
+                  <TimelineItem
+                    isLast={i === item.children.length - 1}
+                    item={child}
+                    key={child.id ?? i}
+                  />
+                ))}
+              </ul>
+            )}
+          </>
+        ) : (
+          <div className="space-y-0.5">
+            <div className="flex flex-wrap items-center gap-x-2">
+              <span className="font-medium text-p3-text text-sm dark:text-p3-text-dark">
+                {item.title}
+              </span>
+              {item.time && <span className="text-neutral-400 text-xs">{item.time}</span>}
+            </div>
+            {item.description && (
+              <p className="text-neutral-500 text-xs dark:text-neutral-400">{item.description}</p>
+            )}
           </div>
-          {item.description && (
-            <p className="text-neutral-500 text-xs dark:text-neutral-400">{item.description}</p>
-          )}
-        </div>
-      )}
+        )}
+      </div>
     </li>
   );
 }
@@ -114,7 +121,7 @@ function TimelineItem({ item, isLast }) {
  */
 export function Timeline({ items = [], className }) {
   return (
-    <ul className={cn("space-y-4", className)}>
+    <ul className={cn("flex flex-col", className)}>
       {items.map((item, i) => (
         <TimelineItem isLast={i === items.length - 1} item={item} key={item.id ?? i} />
       ))}

--- a/components/ui/timeline.jsx
+++ b/components/ui/timeline.jsx
@@ -17,9 +17,13 @@ const STATUS = {
   warning: { className: "text-amber-500 dark:text-amber-400", icon: CircleDot },
 };
 
+const INDENT = 22; // px each nesting level shifts right
+const MARKER = 18; // px marker size
+const center = (level) => level * INDENT + MARKER / 2;
+
 function EventMarker({ status }) {
   const { icon: Icon, className } = STATUS[status] ?? STATUS.info;
-  return <Icon className={cn("size-[18px] shrink-0", className)} strokeWidth={2} />;
+  return <Icon className={cn("size-[18px]", className)} strokeWidth={2} />;
 }
 
 function GroupToggle({ open, onClick }) {
@@ -27,7 +31,7 @@ function GroupToggle({ open, onClick }) {
     <button
       aria-expanded={open}
       aria-label={open ? "Collapse group" : "Expand group"}
-      className="flex size-[18px] shrink-0 items-center justify-center rounded-full border border-p3-border text-neutral-500 transition-colors hover:text-p3-text dark:border-p3-border-dark dark:hover:text-p3-text-dark"
+      className="flex size-[18px] items-center justify-center rounded-full border border-p3-border bg-p3-background-light text-neutral-500 transition-colors hover:text-p3-text dark:border-p3-border-dark dark:bg-p3-background-dark dark:hover:text-p3-text-dark"
       onClick={onClick}
       type="button"
     >
@@ -36,60 +40,76 @@ function GroupToggle({ open, onClick }) {
   );
 }
 
-function TimelineItem({ item, isLast }) {
-  const isGroup = Array.isArray(item.children) && item.children.length > 0;
-  const [open, setOpen] = useState(item.defaultOpen ?? false);
-  const toggle = () => setOpen((v) => !v);
+/**
+ * A single connector running from this row's marker to the next visible row's
+ * marker. Straight when the level is unchanged; a rounded elbow when entering
+ * (step right) or leaving (step left) a nesting level — together these form one
+ * continuous line that weaves into and out of nested groups.
+ */
+function Connector({ level, nextLevel }) {
+  const c = center(level);
+  const n = center(nextLevel);
+  const base = "absolute z-0 border-p3-border dark:border-p3-border-dark";
+
+  if (nextLevel === level) {
+    return (
+      <span
+        aria-hidden
+        className={cn(base, "border-l")}
+        style={{ bottom: 0, left: c, top: MARKER }}
+      />
+    );
+  }
+  if (nextLevel > level) {
+    return (
+      <span
+        aria-hidden
+        className={cn(base, "rounded-bl-[10px] border-b border-l")}
+        style={{ bottom: 0, left: c, top: MARKER, width: n - c }}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      className={cn(base, "rounded-br-[10px] border-r border-b")}
+      style={{ bottom: 0, left: n, top: MARKER, width: c - n }}
+    />
+  );
+}
+
+function Row({ row, nextLevel }) {
+  const { item, level, isGroup, open, onToggle } = row;
 
   return (
-    <li className="flex gap-3">
-      {/* gutter: marker on top, connector line growing toward the next item */}
-      <div className="flex flex-col items-center">
+    <div className="relative flex items-start gap-2" style={{ paddingLeft: level * INDENT }}>
+      {nextLevel != null && <Connector level={level} nextLevel={nextLevel} />}
+
+      <div className="relative z-10 shrink-0">
         {isGroup ? (
-          <GroupToggle onClick={toggle} open={open} />
+          <GroupToggle onClick={onToggle} open={open} />
         ) : (
           <EventMarker status={item.status} />
         )}
-        {!isLast && (
-          <span aria-hidden className="mt-1.5 w-px grow bg-p3-border dark:bg-p3-border-dark" />
-        )}
       </div>
 
-      {/* content */}
-      <div className={cn("min-w-0 flex-1", !isLast && "pb-4")}>
+      <div className="min-w-0 flex-1 pb-4">
         {isGroup ? (
-          <>
-            <button className="flex items-center gap-1.5 text-left" onClick={toggle} type="button">
-              {item.title && (
-                <span className="font-medium text-p3-text text-sm dark:text-p3-text-dark">
-                  {item.title}
-                </span>
-              )}
-              <span className="text-neutral-400 text-xs">
-                {item.title
-                  ? `${item.children.length} events`
-                  : `${item.children.length} more events`}
+          <button className="flex items-center gap-1.5 text-left" onClick={onToggle} type="button">
+            {item.title && (
+              <span className="font-medium text-p3-text text-sm dark:text-p3-text-dark">
+                {item.title}
               </span>
-              <ChevronRight
-                className={cn(
-                  "size-3.5 text-neutral-400 transition-transform",
-                  open && "rotate-90",
-                )}
-              />
-            </button>
-
-            {open && (
-              <ul className="mt-4 space-y-0">
-                {item.children.map((child, i) => (
-                  <TimelineItem
-                    isLast={i === item.children.length - 1}
-                    item={child}
-                    key={child.id ?? i}
-                  />
-                ))}
-              </ul>
             )}
-          </>
+            <span className="text-neutral-400 text-xs">
+              {item.title
+                ? `${item.children.length} events`
+                : `${item.children.length} more events`}
+            </span>
+            <ChevronRight
+              className={cn("size-3.5 text-neutral-400 transition-transform", open && "rotate-90")}
+            />
+          </button>
         ) : (
           <div className="space-y-0.5">
             <div className="flex flex-wrap items-center gap-x-2">
@@ -104,12 +124,37 @@ function TimelineItem({ item, isLast }) {
           </div>
         )}
       </div>
-    </li>
+    </div>
   );
 }
 
+/** Collect keys of groups that should start open. */
+function collectOpen(items, parentKey, acc) {
+  items.forEach((item, i) => {
+    const key = item.id ?? `${parentKey}/${i}`;
+    if (Array.isArray(item.children) && item.children.length > 0) {
+      if (item.defaultOpen) acc.add(key);
+      collectOpen(item.children, key, acc);
+    }
+  });
+  return acc;
+}
+
+/** Flatten the visible tree (respecting open state) into ordered rows. */
+function flatten(items, openIds, level, parentKey, acc) {
+  items.forEach((item, i) => {
+    const key = item.id ?? `${parentKey}/${i}`;
+    const isGroup = Array.isArray(item.children) && item.children.length > 0;
+    const open = isGroup && openIds.has(key);
+    acc.push({ isGroup, item, key, level, open });
+    if (open) flatten(item.children, openIds, level + 1, key, acc);
+  });
+  return acc;
+}
+
 /**
- * Timeline — renders a (optionally nested) timeline of events.
+ * Timeline — renders a (optionally nested) timeline of events as one continuous
+ * line that weaves into and out of collapsible groups.
  *
  * @param {Object[]} items - event nodes
  * @param {string}   items[].title       - event label (omit on a group to render "N more events")
@@ -120,11 +165,26 @@ function TimelineItem({ item, isLast }) {
  * @param {boolean} [items[].defaultOpen]
  */
 export function Timeline({ items = [], className }) {
+  const [openIds, setOpenIds] = useState(() => collectOpen(items, "", new Set()));
+
+  const toggle = (key) =>
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+
+  const rows = flatten(items, openIds, 0, "", []);
+
   return (
-    <ul className={cn("flex flex-col", className)}>
-      {items.map((item, i) => (
-        <TimelineItem isLast={i === items.length - 1} item={item} key={item.id ?? i} />
+    <div className={cn("flex flex-col", className)}>
+      {rows.map((row, i) => (
+        <Row
+          key={row.key}
+          nextLevel={i < rows.length - 1 ? rows[i + 1].level : null}
+          row={{ ...row, onToggle: () => toggle(row.key) }}
+        />
       ))}
-    </ul>
+    </div>
   );
 }


### PR DESCRIPTION
Add a reusable, nested/collapsible Timeline component (components/ui/timeline.jsx)
with status-based markers, plus a doc-style ComponentShowcase wrapper and a
/playground page demoing it.

https://claude.ai/code/session_01C8hQyDQc88pKwMwvRttmQJ